### PR TITLE
reposition badges for cards in list item mode

### DIFF
--- a/src/card/parts/Card.scss
+++ b/src/card/parts/Card.scss
@@ -89,11 +89,14 @@
 
 	.badges {
 		position: absolute;
-		top: 0;
-		left: 0;
+		bottom: 0;
+		left: 90px;
+		margin: 0 5px;
 		list-style: none;
 		padding: 0;
-		margin: 0;
+		display: flex;
+		white-space: nowrap;
+		transform: translateY(50%);
 	}
 
 	.nti-course-card-image {


### PR DESCRIPTION
Positions badges along the bottom of the list-item card, per Madison's design.