### PR TITLE
move list variant logic to web commons

### DIFF
--- a/src/card/parts/Card.jsx
+++ b/src/card/parts/Card.jsx
@@ -34,13 +34,11 @@ export default function CourseCard({
 	className,
 	course,
 	badges,
-	variant = 'card',
+	variant: v = 'card',
 	progress,
 	onClick,
 }) {
-	if (variant === 'auto') {
-		variant = useListItemVariant();
-	}
+	const variant = useListItemVariant(v);
 
 	return (
 		<div


### PR DESCRIPTION
Moves the Card variant media query logic to a hook in web commons. This depends on [web commons PR 171](https://github.com/NextThought/nti.web.commons/pull/171).