### PR TITLE
place sortable collection alongside original

### DIFF
--- a/src/collection-sortable/Page.jsx
+++ b/src/collection-sortable/Page.jsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { scoped } from '@nti/lib-locale';
+import {
+	Loading,
+	Scroll,
+	Page,
+	Hooks,
+	Button,
+	Layouts,
+} from '@nti/web-commons';
+import { WithSearch } from '@nti/web-search';
+
+import Store from './Store';
+import Grid from './components/Grid';
+import Group from './components/Group';
+import Empty from './components/Empty';
+import ResultsLabel from './components/ResultsLabel';
+
+const { useMobileValue } = Hooks;
+
+const t = scoped('course.collection.Page', {
+	search: {
+		AdministeredCourses: 'Administered Courses',
+		EnrolledCourses: 'Enrolled Courses',
+	},
+	results: 'Showing Results for "%(term)s"',
+	loadMore: 'Load More',
+});
+
+const Footer = styled.div`
+	margin-bottom: 2rem;
+	text-align: center;
+`;
+
+const LoadMore = styled(Button)`
+	width: 98%;
+	display: block;
+	margin: 0 auto;
+`;
+
+const ControlsContainer = props => <Grid singleColumn {...props} />;
+const Controls = styled(ControlsContainer)`
+	margin-bottom: var(--gap, 14px);
+`;
+
+CourseCollection.propTypes = {
+	collection: PropTypes.oneOfType([
+		PropTypes.shape({
+			title: PropTypes.string,
+			getLink: PropTypes.func,
+		}),
+		PropTypes.oneOf(['AdministeredCourses', 'EnrolledCourses']),
+	]),
+
+	getSectionTitle: PropTypes.func,
+};
+
+function CourseCollection({ getSectionTitle, children }) {
+	const {
+		collection,
+
+		loading,
+		error,
+
+		groups,
+		loadMore,
+		hasMore,
+
+		onCourseDelete,
+	} = Store.useValue();
+
+	const mobile = useMobileValue(true);
+
+	const initialLoading = loading && !error && !groups;
+	const loadingMore = loading && !initialLoading;
+
+	const empty =
+		!groups?.length || groups?.every(g => g.Items && g.Items.length === 0);
+
+	const scrollerRef = React.useRef();
+
+	React.useEffect(() => {
+		if (loading) {
+			return;
+		}
+
+		const timeout = setTimeout(() => {
+			if (!scrollerRef.current) {
+				return;
+			}
+
+			if (!scrollerRef.current.canScroll() && hasMore) {
+				loadMore();
+			}
+		}, 100);
+
+		return () => clearTimeout(timeout);
+	}, [loading, hasMore, loadMore]);
+
+	return (
+		<Scroll.BoundaryMonitor
+			ref={scrollerRef}
+			window
+			onBottom={hasMore ? loadMore : null}
+		>
+			<Page>
+				<Page.Content card={false}>
+					<ResultsLabel empty={empty} />
+					<Loading.Placeholder
+						loading={initialLoading}
+						fallback={<Page.Content.Loading />}
+					>
+						{error && <Page.Content.Error error={error} />}
+						{!error && empty && (
+							<Empty collection={collection} searchTerm />
+						)}
+						{!error &&
+							!empty &&
+							Layouts.Slot.exists('controls', children) && (
+								<Controls>
+									<Layouts.Slot
+										slot="controls"
+										{...{ children }}
+									/>
+								</Controls>
+							)}
+						{(groups ?? []).map(group => (
+							<Group
+								key={group.name}
+								group={group}
+								mobile={mobile}
+								getSectionTitle={getSectionTitle}
+								onCourseDelete={onCourseDelete}
+							/>
+						))}
+						<Footer>
+							{loadingMore && <Loading.Spinner />}
+							{!loadingMore && hasMore && (
+								<LoadMore rounded onClick={loadMore}>
+									{t('loadMore')}
+								</LoadMore>
+							)}
+						</Footer>
+					</Loading.Placeholder>
+				</Page.Content>
+			</Page>
+		</Scroll.BoundaryMonitor>
+	);
+}
+
+const Connected = Store.compose(CourseCollection, {
+	deriveBindingFromProps: ({ collection, sortOn, sortDirection }) => ({
+		collection,
+		sortOn,
+		sortDirection,
+	}),
+});
+
+const title = collection =>
+	typeof collection === 'string' ? collection : collection?.Title;
+
+export default WithSearch(Connected, {
+	context: ({ collection }) => title(collection),
+	label: ({ collection }) => t(`search.${title(collection)}`),
+});

--- a/src/collection-sortable/Store.js
+++ b/src/collection-sortable/Store.js
@@ -1,0 +1,203 @@
+import { Stores, Interfaces } from '@nti/lib-store';
+import { Iterable } from '@nti/lib-commons';
+import { getService } from '@nti/web-client';
+
+import batchGenerator from './utils/batch-generator';
+import combineGroups from './utils/combine-groups';
+import getSemester from './utils/get-semester';
+
+async function resolveCollection(collection) {
+	if (typeof collection !== 'string') {
+		return collection;
+	}
+
+	const service = await getService();
+
+	return service.getCollection(collection, 'Courses');
+}
+
+// const courseSortOptions = [
+// 	'createdTime',
+// 	'provideruniqueid',
+// 	'lastSeenTime',
+// 	'title',
+// ];
+
+const Generators = [
+	{
+		handles: (collection, params) => params.sortOn === 'availability',
+		generator: async function* (collection, params) {
+			const fixedParams = {
+				...params,
+				sortOn: 'startDate',
+				sortDirection: null,
+			};
+			const iterator = Iterable.chain.async(
+				batchGenerator(collection, { ...fixedParams, rel: 'upcoming' }),
+				batchGenerator(collection, { ...fixedParams, rel: 'current' }),
+				batchGenerator(
+					collection,
+					{ ...fixedParams, rel: 'archived' },
+					getSemester
+				)
+			);
+
+			yield* iterator;
+		},
+	},
+	{
+		handles: () => true,
+		generator: batchGenerator,
+	},
+];
+
+class CourseCollectionStore extends Stores.BoundStore {
+	bindingDidUpdate(prevBinding) {
+		return (
+			prevBinding.collection !== this.binding.collection ||
+			prevBinding.sortOn !== this.binding.sortOn ||
+			prevBinding.sortDirection !== this.binding.sortDirection ||
+			prevBinding.filter !== this.binding.filter
+		);
+	}
+
+	applySearchTerm(term) {
+		if ((term ?? '') !== (this.lastSearchTerm ?? '')) {
+			this.setImmediate({
+				loading: true,
+				groups: null,
+			});
+		}
+	}
+
+	getParams() {
+		const params = {
+			sortOn: this.binding.sortOn,
+			sortDirection: this.binding.sortDirection,
+			batchSize: this.binding.batchSize,
+		};
+
+		if (this.searchTerm) {
+			params.filter = this.searchTerm;
+		}
+
+		return params;
+	}
+
+	isCurrentParams(params) {
+		const current = this.getParams();
+
+		return (
+			current.sortOn === params.sortOn &&
+			current.sortDirection === params.sortDirection &&
+			current.batchSize === params.batchSize &&
+			current.filter === params.filter
+		);
+	}
+
+	clearGenerator() {
+		delete this.generator;
+	}
+
+	async load() {
+		if (this.lastParams && this.isCurrentParams(this.lastParams)) {
+			return;
+		}
+
+		this.setImmediate({
+			loading: true,
+			error: null,
+			groups: null,
+			hasMore: false,
+		});
+
+		this.clearGenerator();
+
+		const collection = (this.collection = await resolveCollection(
+			this.binding.collection
+		));
+		const params = (this.lastParams = this.getParams());
+
+		if (!collection) {
+			this.set({
+				groups: [{ name: 'empty', Items: [] }],
+				hasMore: false,
+				loading: false,
+			});
+
+			return;
+		}
+
+		try {
+			const handler = Generators.find(g =>
+				g.handles?.(collection, params)
+			);
+			this.generator = handler?.generator(collection, params);
+
+			if (!this.generator) {
+				throw new Error('Unknown sort');
+			}
+
+			const initialGroups = await this.generator.next();
+
+			//if the params have changed we don't want to set these results
+			if (!this.isCurrentParams(params)) {
+				return;
+			}
+
+			this.setImmediate({
+				collection,
+				loading: false,
+				groups: initialGroups.value,
+				hasMore: !initialGroups.done,
+			});
+		} catch (e) {
+			if (!this.isCurrentParams(params)) {
+				return;
+			}
+
+			this.set({
+				loading: false,
+				error: e,
+			});
+		}
+	}
+
+	async loadMore() {
+		const { generator } = this;
+
+		if (!generator || this.get('loading')) {
+			return;
+		}
+
+		this.setImmediate({
+			loading: true,
+		});
+
+		const current = this.get('groups');
+		const next = await generator.next();
+
+		if (this.generator !== generator) {
+			return;
+		}
+
+		this.set({
+			loading: false,
+			groups: next.value ? combineGroups(current, next.value) : current,
+			hasMore: !next.done,
+		});
+	}
+
+	onCourseDelete(course) {
+		this.setImmediate({
+			groups: (this.get('groups') ?? []).map(group => {
+				return {
+					...group,
+					Items: (group.Items ?? []).filter(c => c !== course),
+				};
+			}),
+		});
+	}
+}
+
+export default Interfaces.Searchable(CourseCollectionStore);

--- a/src/collection-sortable/components/Empty.jsx
+++ b/src/collection-sortable/components/Empty.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { scoped } from '@nti/lib-locale';
+import { EmptyState, Theme } from '@nti/web-commons';
+
+import Store from '../Store';
+
+const t = scoped('course.collection.components.Empty', {
+	AdministeredCourses: 'No Administered Courses',
+	default: 'No Courses',
+	search: {
+		AdministeredCourses: 'No Matching Administered Courses',
+		default: 'No Matching Courses',
+	},
+});
+
+const Empty = styled(EmptyState)`
+	color: white;
+	opacity: 0.5;
+
+	&.dark {
+		color: var(--secondary-grey);
+		opacity: 1;
+	}
+`;
+
+export default function EmptyCourseCollection() {
+	const { collection, searchTerm } = Store.useValue();
+
+	const background = Theme.useThemeProperty('background');
+	const lightBackground = background === 'light';
+	const getKey = scope => `${searchTerm ? 'search.' : ''}${scope}`;
+
+	let key = [collection?.Title, 'default']
+		.map(getKey)
+		.find(x => !t.isMissing(x));
+
+	if (t.isMissing(key)) {
+		return null;
+	}
+
+	return <Empty header={t(key)} dark={lightBackground} />;
+}

--- a/src/collection-sortable/components/Grid.jsx
+++ b/src/collection-sortable/components/Grid.jsx
@@ -1,0 +1,3 @@
+import { Layouts } from '@nti/web-commons';
+
+export default Layouts.grid(242, 14);

--- a/src/collection-sortable/components/Group.jsx
+++ b/src/collection-sortable/components/Group.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Errors } from '@nti/web-commons';
+
+import Card from '../../card/View';
+
+import Grid from './Grid';
+import GroupHeader from './GroupHeader';
+
+const Section = styled('section')`
+	margin-bottom: 2rem;
+
+	&.mobile {
+		padding: 0 0.625rem;
+	}
+`;
+
+const getKey = item => item.getID() ?? item.CatalogEntry?.getID();
+
+CourseCollectionGroup.propTypes = {
+	group: PropTypes.shape({
+		Items: PropTypes.array,
+		error: PropTypes.any,
+	}),
+
+	mobile: PropTypes.bool,
+
+	getSectionTitle: PropTypes.func,
+	onCourseDelete: PropTypes.func,
+	onSortChange: PropTypes.func,
+};
+export default function CourseCollectionGroup({
+	group,
+	mobile,
+	getSectionTitle,
+	onCourseDelete,
+	onSortChange,
+}) {
+	if (group.error) {
+		return <Errors.Message as="p" error={group.error} />;
+	}
+
+	if (!group?.Items || group.Items.length === 0) {
+		return null;
+	}
+
+	return (
+		<Section mobile={mobile}>
+			<GroupHeader
+				group={group}
+				mobile={mobile}
+				getSectionTitle={getSectionTitle}
+				onSortChange={onSortChange}
+			/>
+			<Grid as="ul">
+				{columns =>
+					group.Items.map(item => (
+						<li key={getKey(item)}>
+							<Card
+								course={item}
+								onDelete={onCourseDelete}
+								variant={columns === 1 ? 'list-item' : 'card'}
+							/>
+						</li>
+					))
+				}
+			</Grid>
+		</Section>
+	);
+}

--- a/src/collection-sortable/components/GroupHeader.jsx
+++ b/src/collection-sortable/components/GroupHeader.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { scoped } from '@nti/lib-locale';
+import { Text, Theme } from '@nti/web-commons';
+
+import Grid from './Grid';
+
+//TODO: move the locale strings here from library/components/SectionTitle
+const t = scoped('course.collection.GroupHeader', {
+	upcoming: 'Upcoming Courses',
+	current: 'Current Courses',
+	archived: 'Archived Courses',
+});
+
+const getLocale = s => (t.isMissing(s) ? s : t(s));
+
+const Header = styled('h1')`
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
+	margin: 0;
+`;
+
+const Name = styled(Text.Base)`
+	font-size: 1.125rem;
+	font-weight: 300;
+	line-height: 2;
+	color: var(--secondary-grey);
+
+	&.light {
+		color: white;
+	}
+`;
+
+const Sub = styled(Text.Base)`
+	font-size: 1.125rem;
+	font-weight: 300;
+	line-height: 2;
+	opacity: 0.3;
+	color: var(--secondary-grey);
+	margin-left: 0.5rem;
+
+	&.light {
+		color: white;
+	}
+`;
+
+GroupHeader.propTypes = {
+	group: PropTypes.shape({
+		name: PropTypes.string,
+		parent: PropTypes.string,
+	}),
+	getSectionTitle: PropTypes.func,
+};
+export default function GroupHeader({ group, getSectionTitle = getLocale }) {
+	const background = Theme.useThemeProperty('background');
+	const lightBackground = background === 'light';
+
+	const name = group.parent ?? group.name;
+	const sub = group.parent ? group.name : null;
+
+	if (name === 'self') {
+		return null;
+	}
+
+	return (
+		<Grid singleColumn>
+			<Header>
+				{name && (
+					<Name light={!lightBackground}>
+						{getSectionTitle(name)}
+					</Name>
+				)}
+				{sub && (
+					<Sub light={!lightBackground}>{getSectionTitle(sub)}</Sub>
+				)}
+			</Header>
+		</Grid>
+	);
+}

--- a/src/collection-sortable/components/ResultsLabel.jsx
+++ b/src/collection-sortable/components/ResultsLabel.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+import { scoped } from '@nti/lib-locale';
+import { Text, Theme } from '@nti/web-commons';
+
+import Store from '../Store';
+
+const t = scoped('course.collection.components.ResultsLabel', {
+	results: 'Showing results for "%(searchTerm)s"',
+});
+
+const Label = styled(Text.Base).attrs({ as: 'div' })`
+	font-size: 1.125rem;
+	text-align: center;
+	color: white;
+
+	&.dark {
+		color: var(--secondary-grey);
+	}
+`;
+
+ResultsLabel.propTypes = {
+	empty: PropTypes.bool,
+};
+export default function ResultsLabel({ empty }) {
+	const { searchTerm } = Store.useValue();
+
+	const background = Theme.useThemeProperty('background');
+	const lightBackground = background === 'light';
+
+	if (!searchTerm) {
+		return null;
+	}
+
+	return (
+		<Label dark={lightBackground}>
+			{t('results', { searchTerm })}
+		</Label>
+	);
+}

--- a/src/collection-sortable/index.js
+++ b/src/collection-sortable/index.js
@@ -1,0 +1,15 @@
+import { scoped } from '@nti/lib-locale';
+
+export { default as Page } from './Page';
+export { default as Grid } from './components/Grid';
+export { default as Group } from './components/Group';
+export { default as Store } from './Store';
+
+export const getSortOptionText = scoped('course.sorting', {
+	availability: 'By Availability',
+	favorites: 'By Magic',
+	createdTime: 'By Date Added',
+	provideruniqueid: 'By ID',
+	lastSeenTime: 'By Last Opened',
+	title: 'By Title',
+});

--- a/src/collection-sortable/utils/__test__/combine-groups.spec.js
+++ b/src/collection-sortable/utils/__test__/combine-groups.spec.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+import combineGroups from '../combine-groups';
+
+describe('combine course collection groups', () => {
+	test('combines if the adjacent group names are the same', () => {
+		const combined = combineGroups(
+			[
+				{ name: 'group1', Items: ['first'] },
+				{ name: 'group2', Items: ['second'] },
+			],
+			[
+				{ name: 'group2', Items: ['third'] },
+				{ name: 'group3', Items: ['fourth'] },
+			]
+		);
+
+		expect(combined.length).toBe(3);
+
+		expect(combined[0].Items.length).toBe(1);
+		expect(combined[0].Items[0]).toBe('first');
+
+		expect(combined[1].Items.length).toBe(2);
+		expect(combined[1].Items[0]).toBe('second');
+		expect(combined[1].Items[1]).toBe('third');
+
+		expect(combined[2].Items.length).toBe(1);
+		expect(combined[2].Items[0]).toBe('fourth');
+	});
+});

--- a/src/collection-sortable/utils/batch-generator.js
+++ b/src/collection-sortable/utils/batch-generator.js
@@ -1,0 +1,37 @@
+import { getService } from '@nti/web-client';
+
+import combineGroups from './combine-groups';
+
+const BatchSize = 20;
+
+export default async function* batchGenerator(collection, params, grouper) {
+	const service = await getService();
+	const rel = params.rel ?? 'self';
+
+	let offset = 0;
+	let done = false;
+
+	while (!done) {
+		const batch = await service.getBatch(collection.getLink(rel), {
+			batchSize: BatchSize,
+			batchStart: offset,
+			...params,
+		});
+
+		if (batch.Items.length < BatchSize) {
+			done = true;
+		}
+
+		const groups = grouper
+			? combineGroups(
+					batch.Items.map(i => ({
+						name: grouper(i),
+						parent: params.rel,
+						Items: [i],
+					}))
+			  )
+			: [{ name: rel, Items: batch.Items }];
+
+		yield groups;
+	}
+}

--- a/src/collection-sortable/utils/combine-groups.js
+++ b/src/collection-sortable/utils/combine-groups.js
@@ -1,0 +1,26 @@
+/**
+ * Given a list of groups ([{name: 'Group Name', Items: [course1, course1]}])
+ * combine adjacent groups tht have the same name.
+ *
+ *
+ * @param  {...any} groupArgs set of groups to combine
+ * @returns {Array} the combined set of groups
+ */
+export default function combineGroups(...groupArgs) {
+	const combined = [];
+
+	for (let groups of groupArgs) {
+		for (let group of groups) {
+			const last = combined[combined.length - 1];
+
+			if (last && last.name === group.name) {
+				last.Items = [...last.Items, ...group.Items];
+				last.error = last.error ?? group.error;
+			} else {
+				combined.push(group);
+			}
+		}
+	}
+
+	return combined;
+}

--- a/src/collection-sortable/utils/get-semester.js
+++ b/src/collection-sortable/utils/get-semester.js
@@ -1,0 +1,40 @@
+const months = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+];
+
+export function getEffectiveDate(course) {
+	// if there is no start date, but we have an end date, consider that end date
+	// as the 'effective' date for the course.  So when determining which semester an archived
+	// course occurred, basing it on the EndDate is our only option without a StartDate
+	return course.getStartDate() || course.getEndDate();
+}
+
+export function getSemester(course) {
+	let start = getEffectiveDate(course),
+		month = start && start.getMonth(),
+		s = start && months[month];
+	return s || '';
+}
+
+export default function getSemesterText(course) {
+	let start = getEffectiveDate(course),
+		year = start && start.getFullYear(),
+		semester = getSemester(course);
+
+	if (!start) {
+		return '';
+	}
+
+	return semester + ' ' + year;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { default as Card } from './card';
 export { default as Community } from './community';
 export { default as CourseCreateButton } from './CreateButton';
 export * as Collection from './collection';
+export * as CollectionSortable from './collection-sortable';
 export * as Content from './content';
 export * as Editor from './editor';
 export * as Info from './info';


### PR DESCRIPTION
This PR places the library sorting changes in a `collection-sortable` directory alongside the original `collection` to facilitate feature flaggability. We'll obviously want to clean this up once we're satisfied that it works, but doing it this way allows the originals to remain untouched and entirely separate.