### PR TITLE
NTI-10632 load more generator

### DIFF
--- a/src/collection-sortable/utils/batch-generator.js
+++ b/src/collection-sortable/utils/batch-generator.js
@@ -34,7 +34,15 @@ export async function* batchGenerator(collection, params, grouper) {
 						Items: [i],
 					}))
 			  )
-			: [{ name: rel, Items: batch.Items }];
+			: [
+					{
+						name: rel,
+						Items: batch.Items,
+						Total: batch.Total,
+						batchSize,
+						batchDone: done,
+					},
+			  ];
 
 		yield groups;
 	}


### PR DESCRIPTION
When we're loading courses via a generator that uses chained iterators internally, as we do with the availability sort (current courses, then administered courses, then archived) the following situation may arise:

* The current iterator is done.
* The generator is not done because it has one or more remaining iterators.
* The remaining iterator(s) don't yield any values (as when a user has no administered courses).

This can manifest itself in the UI as a "Load More" button that doesn't appear to do anything. You click it and the button goes away but no additional content is displayed. This leaves the impression that the button was displayed erroneously.

To avoid this scenario, this PR modifies the store's `loadMore` method to invoke `generator.next()` again as long as the following conditions are true:

* The generator hasn't changed while we were awaiting.
* The generator isn't done.
* `next()` returns a value.
* The number of items returned is less than `batchSize`

It's still possible for the "Load More" situation to occur if the number of items happens to match the batch size exactly, but this will make it far less likely.

This is related to [NTI-10632](https://nextthought.atlassian.net/browse/NTI-10632) but extends beyond that specific case.