### PR TITLE
provide UI feedback during course drop

### DIFF
--- a/src/SettingsMenu.jsx
+++ b/src/SettingsMenu.jsx
@@ -24,6 +24,8 @@ SettingsMenu.propTypes = {
 	onExport: PropTypes.func,
 	onDelete: PropTypes.func,
 	onDrop: PropTypes.func,
+	onBeforeDrop: PropTypes.func,
+	onAfterDrop: PropTypes.func,
 	registered: PropTypes.bool,
 	supportContact: PropTypes.string,
 };
@@ -32,6 +34,8 @@ export function SettingsMenu({
 	course,
 	onDelete,
 	onDrop,
+	onBeforeDrop: beforeDrop,
+	onAfterDrop: afterDrop,
 	onEdit,
 	onExport,
 	registered,
@@ -52,6 +56,7 @@ export function SettingsMenu({
 				as={DestructiveOption}
 				course={course}
 				onDrop={onDrop}
+				listeners={{ beforeDrop, afterDrop }}
 				icon={false}
 				data-testid="drop-course"
 			/>

--- a/src/collection-sortable/Page.jsx
+++ b/src/collection-sortable/Page.jsx
@@ -69,6 +69,8 @@ function CourseCollection({ getSectionTitle, children }) {
 		hasMore,
 
 		onCourseDelete,
+		onBeforeDrop,
+		onAfterDrop,
 	} = Store.useValue();
 
 	const mobile = useMobileValue(true);
@@ -133,6 +135,8 @@ function CourseCollection({ getSectionTitle, children }) {
 								mobile={mobile}
 								getSectionTitle={getSectionTitle}
 								onCourseDelete={onCourseDelete}
+								onBeforeDrop={onBeforeDrop}
+								onAfterDrop={onAfterDrop}
 							/>
 						))}
 						<Footer>

--- a/src/collection-sortable/Store.js
+++ b/src/collection-sortable/Store.js
@@ -221,7 +221,9 @@ class CourseCollectionStore extends Stores.BoundStore {
 		});
 	}
 
-	onCourseDelete(course) {
+	onCourseDelete = course => this.#removeCourse(course);
+
+	#removeCourse = course =>
 		this.setImmediate({
 			groups: (this.get('groups') ?? []).map(group => {
 				return {
@@ -230,7 +232,9 @@ class CourseCollectionStore extends Stores.BoundStore {
 				};
 			}),
 		});
-	}
+
+	onAfterDrop = ({ course, error }) =>
+		error ? void 0 : this.#removeCourse(course);
 }
 
 export const Store = Interfaces.Searchable(CourseCollectionStore);

--- a/src/collection-sortable/components/Group.jsx
+++ b/src/collection-sortable/components/Group.jsx
@@ -28,6 +28,8 @@ CourseCollectionGroup.propTypes = {
 
 	getSectionTitle: PropTypes.func,
 	onCourseDelete: PropTypes.func,
+	onBeforeDrop: PropTypes.func,
+	onAfterDrop: PropTypes.func,
 	onSortChange: PropTypes.func,
 };
 export function CourseCollectionGroup({
@@ -35,6 +37,8 @@ export function CourseCollectionGroup({
 	mobile,
 	getSectionTitle,
 	onCourseDelete,
+	onBeforeDrop,
+	onAfterDrop,
 	onSortChange,
 }) {
 	if (group.error) {
@@ -60,6 +64,8 @@ export function CourseCollectionGroup({
 							<Card
 								course={item}
 								onDelete={onCourseDelete}
+								onBeforeDrop={onBeforeDrop}
+								onAfterDrop={onAfterDrop}
 								variant={columns === 1 ? 'list-item' : 'card'}
 							/>
 						</li>


### PR DESCRIPTION
This PR along with a companion branch in `web.library` provides UI feedback while a course drop request is in-flight and filters the dropped course from the displayed list upon success.

It feels a little brittle feeding these listeners through so many layers of components, but it's consistent with what we're already doing for course deletions and provides opportunity for everything that needs to know about it to know about it (store and card both respond to these to provide feedback).