### PR TITLE
be more conservative about showing the load more button

### DIFF
--- a/src/collection/Page.jsx
+++ b/src/collection/Page.jsx
@@ -123,7 +123,7 @@ function CourseCollection({ getSectionTitle, children }) {
 
 			dispatch({ canScroll });
 
-			if (!scrollerRef.current.canScroll() && hasMore) {
+			if (!canScroll && hasMore) {
 				loadMore();
 			}
 		}, 100);


### PR DESCRIPTION
This PR is an attempt to avoid flashing the load more button in and out as we scroll. The button is only there as a fallback for when the scroll boundary monitor events aren't working--a condition we've heard about but never reproduced.

This change adds some component state to keep track of whether the component has received any such events, and once it has, it ceases showing the load more button. This is predicated on the assumption that the events either work or they don't for a given environment, and once we've received the first event we can be confident that any subsequent events will arrive as expected.

As always, I'm open to better ideas.
